### PR TITLE
Suppress deprecation warning

### DIFF
--- a/capybara_screenshot_idobata.gemspec
+++ b/capybara_screenshot_idobata.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'capybara', '~> 2.0'
-  spec.add_dependency 'rest_client'
+  spec.add_dependency 'rest-client'
 
   spec.add_development_dependency 'bundler',  '~> 1.5'
   spec.add_development_dependency 'cucumber', '~> 1.3.0'


### PR DESCRIPTION
```
WARNING: The rest_client gem is deprecated and will be removed from
RubyGems. Please use rest-client gem instead.
```
