### PR TITLE
Fix test for legacy rubies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in capybara_screenshot_idobata.gemspec
 gemspec
+
+gem 'rack', '~> 1.0' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.2')


### PR DESCRIPTION
Rack 2.0 requires Ruby 2.2.2 or later.
